### PR TITLE
Remove removed '-S' option

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -307,5 +307,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    exec ionice -c 3 smbd -F --debug-stdout --no-process-group </dev/null
 fi


### PR DESCRIPTION
The old version used smbd 4.12, which had a `-S` option to send all logs to stdout. The new version is smbd 4.22 which has removed that option (within a minor version 😱) and replaced it with `--debug-stdout`

From <https://www.samba.org/samba/history/samba-4.15.0.html>:
> All tools are now logging to stderr by default. You can use "--debug-stdout" to change the behavior. All servers will log to stderr at early startup until logging is setup to go to a file by default.
> ...
> smbd:
> --log-stdout  ->    --debug-stdout


After submitting this, I saw that the same PR had been submitted upstream 4 years ago and never merged, and several others who have forked the upstream have made this same change. https://github.com/dperson/samba/pull/405